### PR TITLE
feat: Update free models in config example

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,19 +10,36 @@ api_keys:
 # This section maps a friendly, user-defined name to the specific
 # model string that LiteLLM requires.
 models:
+  # --- Direct Provider Models ---
   "gpt-4-direct":
     litellm_model_name: "gpt-4"
   "claude-opus-direct":
     litellm_model_name: "claude-3-opus-20240229"
+
+  # --- OpenRouter Proxied Models ---
   "openrouter-mixtral":
     litellm_model_name: "openrouter/mistralai/mixtral-8x7b-instruct"
-  # Example of another proxied model
-  # "together-llama3":
-  #   litellm_model_name: "together_ai/meta-llama/Llama-3-70b-chat-hf"
+  "openrouter-kimi-free":
+    litellm_model_name: "openrouter/moonshotai/kimi-k2:free"
+  "openrouter-llama-free":
+    litellm_model_name: "openrouter/nvidia/llama-3.1-nemotron-ultra-253b-v1:free"
+  "openrouter-qwen-coder-free":
+    litellm_model_name: "openrouter/qwen/qwen3-coder-480b-a35b:free"
+  "openrouter-deepseek-free":
+    litellm_model_name: "openrouter/deepseek/r1:free"
+  "openrouter-claude-opus":
+    litellm_model_name: "openrouter/anthropic/claude-3-opus"
+  "openrouter-gemini-pro":
+    litellm_model_name: "openrouter/google/gemini-1.5-pro"
+  "openrouter-command-r-plus":
+    litellm_model_name: "openrouter/cohere/command-r-plus"
+  "openrouter-gpt-4o":
+    litellm_model_name: "openrouter/openai/gpt-4o"
+
 
 # Assign a friendly model name to each agent role. The ModelManager will
 # handle routing it to the correct provider based on the 'models' mapping.
 agent_models:
-  architect: "claude-opus-direct"
-  developer: "openrouter-mixtral"
-  reviewer: "gpt-4-direct"
+  architect: "openrouter-llama-free"
+  developer: "openrouter-qwen-coder-free"
+  reviewer: "openrouter-deepseek-free"


### PR DESCRIPTION
This commit updates the `config.yaml.example` to include a list of powerful free coding models from OpenRouter.

The following changes were made:
- Added several new free and paid models to the `models` section.
- Set the default `agent_models` to use three of the best free models:
  - `architect`: `openrouter-llama-free`
  - `developer`: `openrouter-qwen-coder-free`
  - `reviewer`: `openrouter-deepseek-free`
- The models section was also reorganized for better readability.